### PR TITLE
WIP upgrade `electron`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 ## install
 
+```shell
+git clone git://github.com/mmckegg/audio-splatter
+cd audio-splatter
+npm install
+npm run rebuild
+npm start
+```
+
 ### Debian Linux
 
 install [`node-ftdi`](https://github.com/mmckegg/node-ftdi) using `node_modules/node-ftdi/install.sh` script

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "electron main.js"
+    "start": "electron main.js",
+    "rebuild": "electron-rebuild"
   },
   "repository": {
     "type": "git",
@@ -22,7 +23,6 @@
     "ftdi": "github:mmckegg/node-ftdi",
     "ndarray": "^1.0.18",
     "pixels-canvas": "^1.0.2",
-    "require-rebuild": "^1.2.8",
     "worker-timer": "^1.0.0",
     "ws": "^1.0.1"
   },

--- a/realtime.html
+++ b/realtime.html
@@ -5,7 +5,6 @@
   </head>
   <body>
     <script>
-      require('require-rebuild')()
       require('./realtime.js')
     </script>
   </body>


### PR DESCRIPTION
hey @mmckegg, it seems the latest `electron` doesn't work with [`mmckegg/node-ftdi`](https://github.com/mmckegg/node-ftdi), although i have no idea what the problem is.

```
➜ npm start

> audio-splatter@0.0.0 start /home/dinosaur/repos/ahdinosaur/audio-splatter
> electron main.js


==== C stack trace ===============================

 1: V8_Fatal
 2: 0x7fef04f50d9e
 3: InitializeList(v8::Local<v8::Object>)
 4: init
 5: node::DLOpen(v8::FunctionCallbackInfo<v8::Value> const&)
 6: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&))
 7: 0x7fef04fb51b7
 8: 0x7fef04fb6f86
```

this stack trace also happens when running `node server`, but it actually still works.

my motivation for this change is so we keep up to date with electron, i have a very similar project at [`ahdinosaur/mood-light`](https://github.com/ahdinosaur/mood-light) that currently doesn't use `ftdi` (rather i use the `server` here, hehe).
